### PR TITLE
ChIP-seq workflow patched

### DIFF
--- a/workflows/ChIP-seq/ChIP-seq
+++ b/workflows/ChIP-seq/ChIP-seq
@@ -106,7 +106,7 @@ def parse_args(defaults={"verbose":None,"configfile":None,"max_jobs":None,"snake
                         dest="paired",
                         action="store_false",
                         help="input data is single-end, not paired-end (default: '%(default)s')",
-                        default=not(defaults["paired"]))
+                        default=defaults["paired"])
 
     optional.add_argument("--bw-binsize",
                         dest="bw_binsize",
@@ -145,6 +145,7 @@ def main():
     ## defaults
     defaults = cf.load_configfile(os.path.join(this_script_dir, "defaults.yaml"),False)
 
+    print(defaults)
     ## get command line arguments
     parser = parse_args(defaults)
     args = parser.parse_args()

--- a/workflows/ChIP-seq/ChIP-seq
+++ b/workflows/ChIP-seq/ChIP-seq
@@ -145,7 +145,6 @@ def main():
     ## defaults
     defaults = cf.load_configfile(os.path.join(this_script_dir, "defaults.yaml"),False)
 
-    print(defaults)
     ## get command line arguments
     parser = parse_args(defaults)
     args = parser.parse_args()


### PR DESCRIPTION
Fixed problem that ChIP-seq workflow runs only in single-end mode, regardless of user config file.